### PR TITLE
Move async to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,11 +37,11 @@
   "homepage": "https://github.com/ipfs/js-ipfs-block#readme",
   "devDependencies": {
     "aegir": "^9.2.1",
-    "async": "^2.1.4",
     "chai": "^3.5.0",
     "multihashes": "^0.3.0"
   },
   "dependencies": {
+    "async": "^2.1.4",
     "multihashing-async": "^0.3.0"
   },
   "engines": {


### PR DESCRIPTION
Is used by the src/ of the module, should be installed when running `npm install ipfs-block`. Hopefully fixes https://github.com/ipfs/js-ipfs-block/pull/22