### PR TITLE
feat: use class-is module for type checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "chai": "^4.1.2"
   },
   "dependencies": {
-    "cids": "^0.5.2"
+    "cids": "^0.5.3",
+    "class-is": "^1.1.0"
   },
   "engines": {
     "node": ">=6.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const CID = require('cids')
+const withIs = require('class-is')
 
 /**
  * Represents an immutable block of data that is uniquely referenced with a cid.
@@ -51,16 +52,6 @@ class Block {
   set cid (val) {
     throw new Error('Tried to change an immutable block')
   }
-
-  /**
-   * Check if the given value is a Block.
-   *
-   * @param {any} other
-   * @returns {bool}
-   */
-  static isBlock (other) {
-    return other && other.constructor.name === 'Block'
-  }
 }
 
-module.exports = Block
+module.exports = withIs(Block, { className: 'Block', symbolName: '@ipfs/js-ipfs-block/block' })


### PR DESCRIPTION
This is an ongoing effort to fix the https://github.com/ipfs/js-ipfs/issues/938 issue.

It uses a module I've published that abstracts this solution: https://github.com/ipfs/js-ipfs/issues/1131#issuecomment-373299739.