### PR TITLE
chore: use tildes for pre-v1 deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "chai": "^4.1.2"
   },
   "dependencies": {
-    "cids": "^0.5.3",
+    "cids": "~0.5.3",
     "class-is": "^1.1.0"
   },
   "engines": {


### PR DESCRIPTION
> Our rule is: Use ~ for everything below 1.0.0 and ^ for everything above 1.0.0. If you find a package.json that is not following this rule, please submit a PR.

https://github.com/ipfs/community/blob/master/js-code-guidelines.md#dependency-versions