### PR TITLE
refactor: default to CID v1 and encode with base32

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "chai": "^4.2.0"
   },
   "dependencies": {
-    "cids": "~0.5.5",
+    "cids": "github:multiformats/js-cid#refactor/cidv1base32-default",
     "class-is": "^1.1.0"
   },
   "engines": {


### PR DESCRIPTION
Not breaking, can be released in a patch version.

Depends on:

* [ ] https://github.com/multiformats/js-cid/pull/73