### PR TITLE
chore: update cids dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "chai": "^4.2.0"
   },
   "dependencies": {
-    "cids": "~0.5.7",
+    "cids": "~0.7.0",
     "class-is": "^1.1.0"
   },
   "engines": {


### PR DESCRIPTION
Note that since this module does not return CIDs, this change could be released as a patch version.

Please release ASAP.