### PR TITLE
fix: replace node buffers with uint8arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,20 +21,23 @@
 
 ## Table of Contents
 
-- [Install](#install)
-  - [npm](#npm)
-- [Usage](#usage)
-  - [Node.js](#nodejs)
-    - [Example](#example)
-  - [Browser: Browserify, Webpack, other bundlers](#browser-browserify-webpack-other-bundlers)
-  - [Browser: `<script>` Tag](#browser-script-tag)
-- [API](#api)
-  - [Block](#block)
-    - [`new Block(data, cid)`](#new-blockdata-cid)
-    - [`block.data`](#blockdata)
-    - [`block.cid`](#blockcid)
-- [Contribute](#contribute)
-- [License](#license)
+- [IPLD Block JavaScript Implementation](#ipld-block-javascript-implementation)
+  - [Lead Maintainer](#lead-maintainer)
+  - [Table of Contents](#table-of-contents)
+  - [Install](#install)
+    - [npm](#npm)
+  - [Usage](#usage)
+    - [Node.js](#nodejs)
+      - [Example](#example)
+    - [Browser: Browserify, Webpack, other bundlers](#browser-browserify-webpack-other-bundlers)
+    - [Browser: `<script>` Tag](#browser-script-tag)
+  - [API](#api)
+    - [Block](#block)
+      - [`new Block(data, cid)`](#new-blockdata-cid)
+      - [`block.data`](#blockdata)
+      - [`block.cid`](#blockcid)
+  - [Contribute](#contribute)
+  - [License](#license)
 
 ## Install
 
@@ -56,9 +59,10 @@ const Block = require('ipld-block')
 
 ```js
 const Block = require('ipld-block')
+const encoder = new TextEncoder('utf8')
 
 // create a block
-const block = new Block(new Buffer('hello world'), cid)
+const block = new Block(encoder.encode('hello world'), cid)
 console.log(block.data.toString())
 ```
 
@@ -94,7 +98,7 @@ const Block = require('ipld-block')
 
 #### `new Block(data, cid)`
 
-- `data: Buffer`
+- `data: Uint8Array`
 
 Creates a new block with raw data `data`.
 

--- a/package.json
+++ b/package.json
@@ -34,12 +34,11 @@
   },
   "homepage": "https://github.com/ipld/js-ipld-block#readme",
   "devDependencies": {
-    "aegir": "^21.4.5",
-    "chai": "^4.2.0"
+    "aegir": "^25.0.0",
+    "uint8arrays": "^1.0.0"
   },
   "dependencies": {
-    "buffer": "^5.5.0",
-    "cids": "~0.8.0",
+    "cids": "^1.0.0",
     "class-is": "^1.1.0"
   },
   "engines": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const { Buffer } = require('buffer')
 const CID = require('cids')
 const withIs = require('class-is')
 
@@ -8,18 +7,16 @@ const withIs = require('class-is')
  * Represents an immutable block of data that is uniquely referenced with a cid.
  *
  * @constructor
- * @param {Buffer} data - The data to be stored in the block as a buffer.
+ * @param {Uint8Array} data - The data to be stored in the block as a Uint8Array.
  * @param {CID} cid - The cid of the data
  *
  * @example
- * const block = new Block(new Buffer('a012d83b20f9371...'))
+ * const block = new Block(Uint8Array.from([0, 1, 2, 3]), new CID('...'))
  */
 class Block {
   constructor (data, cid) {
-    if (!data || !ArrayBuffer.isView(data)) {
-      throw new Error('first argument  must be a buffer or typed array')
-    } else if (!Buffer.isBuffer(data)) {
-      data = Buffer.from(data.buffer, data.byteOffset, data.byteLength)
+    if (!data || !(data instanceof Uint8Array)) {
+      throw new Error('first argument  must be a Uint8Array')
     }
 
     if (!cid || !CID.isCID(cid)) {
@@ -33,7 +30,7 @@ class Block {
   /**
    * The data of this block.
    *
-   * @type {Buffer}
+   * @type {Uint8Array}
    */
   get data () {
     return this._data

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,8 +1,9 @@
 /* eslint-env mocha */
 'use strict'
 
-const expect = require('chai').expect
+const { expect } = require('aegir/utils/chai')
 const CID = require('cids')
+const uint8ArrayFromString = require('uint8arrays/from-string')
 
 const Block = require('../src')
 
@@ -13,7 +14,7 @@ describe('block', () => {
     ).to.throw()
 
     expect(
-      () => new Block(Buffer.from('hello'), 'cid')
+      () => new Block(uint8ArrayFromString('hello'), 'cid')
     ).to.throw()
 
     expect(
@@ -22,22 +23,13 @@ describe('block', () => {
   })
 
   it('create', () => {
-    const b = new Block(Buffer.from('hello'), new CID('QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n'))
-
-    expect(Block.isBlock(b)).to.eql(true)
-  })
-
-  it('create with Uint8Array', () => {
-    const b = new Block(
-      new Uint8Array([104, 101, 108, 108, 111]),
-      new CID('QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n')
-    )
+    const b = new Block(uint8ArrayFromString('hello'), new CID('QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n'))
 
     expect(Block.isBlock(b)).to.eql(true)
   })
 
   it('block stays immutable', () => {
-    const b = new Block(Buffer.from('hello'), new CID('QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n'))
+    const b = new Block(uint8ArrayFromString('hello'), new CID('QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n'))
 
     expect(
       () => { b.data = 'fail' }


### PR DESCRIPTION
Removes use of node Buffers in favour of Uint8Arrays.

BREAKING CHANGE:

- The `.data` property used to be a Buffer, now it is a Uint8Array