### PR TITLE
feat: add typedef generation

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,3 @@
+{
+  "extends": "ipfs"
+}

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -24,4 +24,4 @@ jobs:
       - name: Install dependencies
         run: npm install
       - name: Typecheck
-        uses: gozala/typescript-error-reporter-action@v1.0.2
+        uses: gozala/typescript-error-reporter-action@v1.0.4

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,0 +1,27 @@
+on:
+  push:
+    branches:
+      - master
+      - main
+      - default
+  pull_request:
+    branches:
+      - '**'
+
+name: Typecheck
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x]
+    steps:
+      - uses: actions/checkout@v1
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install dependencies
+        run: npm install
+      - name: Typecheck
+        uses: gozala/typescript-error-reporter-action@v1.0.2

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "typesVersions": {
     "*": {
       "*": [
-        "dist/types/*"
+        "dist/*"
       ]
     }
   },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
   "main": "src/index.js",
   "scripts": {
     "lint": "aegir lint",
-    "build": "aegir build",
+    "check": "tsc --noEmit --noErrorTruncation",
+    "build": "npm run build:js && npm run build:types",
+    "build:js": "aegir build",
+    "build:types": "tsc --emitDeclarationOnly --declarationDir dist",
     "test": "aegir test",
     "test:node": "aegir test --target node",
     "test:browser": "aegir test --target browser",
@@ -34,16 +37,23 @@
   },
   "homepage": "https://github.com/ipld/js-ipld-block#readme",
   "devDependencies": {
-    "aegir": "^25.0.0",
-    "uint8arrays": "^1.0.0"
+    "aegir": "^27.0.0",
+    "uint8arrays": "^1.0.0",
+    "typescript": "^4.0.3"
   },
   "dependencies": {
-    "cids": "^1.0.0",
-    "class-is": "^1.1.0"
+    "cids": "^1.0.0"
   },
   "engines": {
     "node": ">=6.0.0",
     "npm": ">=3.0.0"
+  },
+  "typesVersions": {
+    "*": {
+      "*": [
+        "dist/types/*"
+      ]
+    }
   },
   "contributors": [
     "David Dias <daviddias.p@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "release-major": "aegir release --type major --docs",
     "coverage": "aegir coverage",
     "coverage-publish": "aegir coverage --provider coveralls",
-    "docs": "aegir docs"
+    "docs": "aegir docs",
+    "prepare": "npm run build:types"
   },
   "pre-push": [
     "lint",

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -34,13 +34,13 @@ describe('block', () => {
     expect(
       () => { b.data = 'fail' }
     ).to.throw(
-      /immutable/
+      /read only/
     )
 
     expect(
       () => { b.cid = 'fail' }
     ).to.throw(
-      /immutable/
+      /read only/
     )
   })
 })

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -23,9 +23,18 @@ describe('block', () => {
   })
 
   it('create', () => {
-    const b = new Block(uint8ArrayFromString('hello'), new CID('QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n'))
+    const cid = new CID('QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n')
+    const data = uint8ArrayFromString('hello')
+    const b = new Block(data, cid)
 
     expect(Block.isBlock(b)).to.eql(true)
+    expect(b.toString()).to.eql('[object Block]')
+    expect(b.data).to.eql(data)
+    expect(b.cid).to.eql(cid)
+    expect(b._data).to.eql(data)
+    expect(b._data).to.eql(data)
+    expect(b._cid).to.eql(cid)
+    expect(b._cid).to.eql(cid)
   })
 
   it('block stays immutable', () => {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -34,13 +34,13 @@ describe('block', () => {
     expect(
       () => { b.data = 'fail' }
     ).to.throw(
-      /read only/
+      /read.only/
     )
 
     expect(
       () => { b.cid = 'fail' }
     ).to.throw(
-      /read only/
+      /read.only/
     )
   })
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,42 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "forceConsistentCasingInFileNames": true,
+    "noImplicitReturns": false,
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "strictFunctionTypes": false,
+    "strictNullChecks": true,
+    "strictPropertyInitialization": true,
+    "strictBindCallApply": true,
+    "strict": true,
+    "alwaysStrict": true,
+    "esModuleInterop": true,
+    "target": "ES2018",
+    "moduleResolution": "node",
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist",
+    "skipLibCheck": true,
+    "stripInternal": true,
+    "resolveJsonModule": true,
+    "paths": {
+      "multiformats": [
+        "src"
+      ]
+    },
+    "baseUrl": "."
+  },
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "vendor",
+    "node_modules"
+  ],
+  "compileOnSave": false
+}


### PR DESCRIPTION
Main goal of this pull request is to start generating typescript typedefs from the jsdocs so that dependent libraries can take advantage of them out of the box. Mainly I'd like this to get better types in js-ipfs (see https://github.com/ipfs/js-ipfs/pull/3281)

This pull request does a little bit more though:

- It gets rid of the `class-is` dependency provides little value but complicates things for both type generation and otherwise.
- Changes `data` and `cid` getters to readonly properties (just like we did successfully in https://github.com/ipld/js-ipld-dag-pb/pull/184)
- Converts `_data` and `_cid` fields to deprecated getters that will start throwing after next major version bump.
- Adds a github action that will run typecheck and report any missmatches inline (just like in https://github.com/multiformats/js-multiformats/pull/41)